### PR TITLE
Playable Mongols and some fixes

### DIFF
--- a/MedievalScenario/MedievalScenarioLoadScreen.lua
+++ b/MedievalScenario/MedievalScenarioLoadScreen.lua
@@ -20,6 +20,7 @@ ScenarioCivilizations = {
 	[9] = "CIVILIZATION_ENGLAND",
 	[10] = "CIVILIZATION_FRANCE",
 	[11] = "CIVILIZATION_AUSTRIA",
+	[12] = "CIVILIZATION_MONGOL",
 }
 
 ----------------------------------------------------------------
@@ -51,6 +52,7 @@ end);
 -- Handle Start Button
 Controls.StartButton:RegisterCallback(Mouse.eLClick, function()
 	
+	local playerIndex2
 	-- Shared settings
 	PreGame.Reset(); -- just in case.
 	PreGame.SetEra(2);   -- Medieval
@@ -81,6 +83,8 @@ Controls.StartButton:RegisterCallback(Mouse.eLClick, function()
 		if(playerIndex ~= nil) then
 			UI.MoveScenarioPlayerToSlot( playerIndex, 0 );
 		end
+		
+		playerIndex2 = playerIndex;
 	else
 		PreGame.SetLoadWBScenario(false);
 	
@@ -110,12 +114,22 @@ Controls.StartButton:RegisterCallback(Mouse.eLClick, function()
 		local randomMap = Modding.GetEvaluatedFilePath(MOD_ID, myModVersion, "Europe_Scenario.lua");
 		PreGame.SetMapScript(randomMap.EvaluatedPath);
 		PreGame.SetMaxTurns(200);
+		
+		playerIndex2 = playerIndex;
 	end
 		
-    PreGame.SetSlotStatus(12, SlotStatus.SS_COMPUTER);
-	PreGame.SetCivilization(12, GameInfo.Civilizations["CIVILIZATION_MONGOL"].ID);
-	PreGame.SetPlayerColor(12, GameInfo.PlayerColors["PLAYERCOLOR_MONGOL"].ID);
-	PreGame.SetLeaderType(12, GameInfo.Leaders["LEADER_GENGHIS_KHAN"].ID);
+	-- Only run if the player did not choose to play mongols
+	if(GameInfo.Civilizations[ScenarioCivilizations[playerIndex2]].ID ~= GameInfo.Civilizations["CIVILIZATION_MONGOL"].ID) then
+		PreGame.SetSlotStatus(12, SlotStatus.SS_COMPUTER);
+		PreGame.SetCivilization(12, GameInfo.Civilizations["CIVILIZATION_MONGOL"].ID);
+		PreGame.SetPlayerColor(12, GameInfo.PlayerColors["PLAYERCOLOR_MONGOL"].ID);
+		PreGame.SetLeaderType(12, GameInfo.Leaders["LEADER_GENGHIS_KHAN"].ID);
+	else
+		PreGame.SetSlotStatus(12, SlotStatus.SS_COMPUTER);
+		PreGame.SetCivilization(12, GameInfo.Civilizations["CIVILIZATION_SPAIN"].ID);
+		PreGame.SetPlayerColor(12, GameInfo.PlayerColors["PLAYERCOLOR_SPAIN"].ID);
+		PreGame.SetLeaderType(12, GameInfo.Leaders["LEADER_ISABELLA"].ID);
+	end
 
 	PreGame.SetGameOption("GAMEOPTION_NO_TUTORIAL", true);
 	

--- a/MedievalScenario/NewCivilizations.xml
+++ b/MedievalScenario/NewCivilizations.xml
@@ -125,6 +125,7 @@
 			<Where Type="CIVILIZATION_MONGOL"/>
 			<Set>
 				<ID>12</ID>
+				<DawnOfManQuote>TXT_KEY_MEDIEVAL_SCENARIO_CIV5_DAWN_TEXT</DawnOfManQuote>
 			</Set>
 		</Update>
 	</Civilizations>

--- a/MedievalScenario/ReligionOverview.lua
+++ b/MedievalScenario/ReligionOverview.lua
@@ -142,10 +142,11 @@ function GetPlayerReligionForScenario(ePlayer)
 	
 	local civType = pPlayer:GetCivilizationType();
 	if (civType == GameInfo.Civilizations["CIVILIZATION_BYZANTIUM"].ID or
-	    civType == GameInfo.Civilizations["CIVILIZATION_RUSSIA"].ID) then
+		civType == GameInfo.Civilizations["CIVILIZATION_RUSSIA"].ID) then
 		iMyCivsReligion = 12;
 	elseif (civType == GameInfo.Civilizations["CIVILIZATION_SONGHAI"].ID or
 	    	civType == GameInfo.Civilizations["CIVILIZATION_OTTOMAN"].ID or
+			civType == GameInfo.Civilizations["CIVILIZATION_MONGOL"].ID or
 	    	civType == GameInfo.Civilizations["CIVILIZATION_ARABIA"].ID) then
 		iMyCivsReligion = 5;
 	elseif (civType == GameInfo.Civilizations["CIVILIZATION_FRANCE"].ID or

--- a/MedievalScenario/TechTreeUpdate.xml
+++ b/MedievalScenario/TechTreeUpdate.xml
@@ -507,6 +507,12 @@
 				<RequiresFaithPurchaseEnabled>1</RequiresFaithPurchaseEnabled>
 			</Set>
 		</Update>
+		<Update>
+			<Where Type="UNIT_HORSEMAN"/>
+			<Set>
+				<ObsoleteTech>TECH_METALLURGY</ObsoleteTech>
+			</Set>
+		</Update>
 		<Row>
 			<Class>UNITCLASS_CROSSBOWMAN</Class>
 			<Type>UNIT_WELSH_LONGBOWMAN</Type>


### PR DESCRIPTION
Changes to allow the player to choose and play as the mongols in the Into The Renaissance scenario. Some additional changes were made to make it more human friendly:

- Mongols are assigned Islam as a religion, rather than having no religion nor pantheon. Old Sarai starts with a majority Islam population.
- Horsemen are obsoleted by Metallurgy instead of Chivalry, so the Mongol player can still have a fast-moving melee unit.
- Human Mongol player is granted the same starting bonuses to gold, faith, and culture as they would playing any other civ, scaled by difficulty.
- Mongol player is granted two scouts on turn 1 so they have something to do while waiting for turn 40 to roll around.

One general bugfix to the scenario:
- Fixed issue where after the first reload, being allies with or owning Jerusalem, or being allied with your Holy city no longer grants your religion's founder benefits.
